### PR TITLE
Add back gnupg dep for Node

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -2,6 +2,7 @@ FROM php:5.6-fpm
 MAINTAINER JH <hello@wearejh.com>
 
 RUN apt-get update \
+    && apt-get install -y gnupg \
     && curl -sL https://deb.nodesource.com/setup_8.x | bash -
 
 RUN apt-get install -y \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -2,6 +2,7 @@ FROM php:7.0-fpm
 MAINTAINER JH <hello@wearejh.com>
 
 RUN apt-get update \
+    && apt-get install -y gnupg \
     && curl -sL https://deb.nodesource.com/setup_8.x | bash -
 
 RUN apt-get install -y \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -2,6 +2,7 @@ FROM php:7.1-fpm
 MAINTAINER JH <hello@wearejh.com>
 
 RUN apt-get update \
+    && apt-get install -y gnupg \
     && curl -sL https://deb.nodesource.com/setup_8.x | bash -
 
 RUN apt-get install -y \

--- a/build.sh
+++ b/build.sh
@@ -16,4 +16,4 @@ fi
 docker pull ${REPO}:${PHPVER}
 docker tag ${REPO}:${PHPVER} ${REPO}:${PHPVER}-current
 
-docker build -f ${PHPVER}/Dockerfile -t ${REPO}:${PHPVER} ${HERE}
+docker build --no-cache -f ${PHPVER}/Dockerfile -t ${REPO}:${PHPVER} ${HERE}


### PR DESCRIPTION
For some reason my local is doing weird things, e.g. not finding packages and also building without the need of those packages just fine. (yes even with --no-cache)

I have now added back gnupg and also made sure builds run no-cache by default anyway, not like it matters much in CI 

Also I ran this using circleci cli tool which runs their docker image and builds inside that, it worked fine and even errored when I didn't have the gnupg dep there. so there was truly something magical happening that I cba to look into. 

Anyway, this should solve things