### PR TITLE
jail commands to www-data, allow build w cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,21 +5,21 @@ jobs:
         machine: true
         steps:
             - checkout
-            - run: ./build.sh 7.1
+            - run: ./build.sh 7.1 --no-cache
             - run: ./publish.sh 7.1
 
     build-5.6:
         machine: true
         steps:
             - checkout
-            - run: ./build.sh 5.6
+            - run: ./build.sh 5.6 --no-cache
             - run: ./publish.sh 5.6
 
     build-7.0:
         machine: true
         steps:
             - checkout
-            - run: ./build.sh 7.0
+            - run: ./build.sh 7.0 --no-cache
             - run: ./publish.sh 7.0
 
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -44,6 +44,8 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini;
 
+RUN usermod -s $(which bash) www-data
+
 ENV COMPOSER_CACHE_DIR /home/www-data/.composer
 ENV HTML_DIR /var/www/htdocs
 ENV MAIL_HOST mail
@@ -69,7 +71,8 @@ RUN curl -O https://files.magerun.net/n98-magerun.phar \
     && mv n98-magerun.phar /usr/local/bin/n98 \
     && chmod +x /usr/local/bin/n98
 
-COPY common/template/ $TEMPLATE_DIR/
+COPY common/template/custom.ini common/template/xdebug.ini /usr/local/etc/php/conf.d/
+COPY common/template/msmtprc $TEMPLATE_DIR/
 
 COPY common/bin/docker-configure /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-configure

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -45,6 +45,8 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini;
 
+RUN usermod -s $(which bash) www-data
+
 ENV COMPOSER_CACHE_DIR /home/www-data/.composer
 ENV MAIL_HOST mail
 ENV MAIL_PORT 1025
@@ -68,7 +70,8 @@ RUN curl -O https://files.magerun.net/n98-magerun2.phar \
     && mv n98-magerun2.phar /usr/local/bin/n98-magerun2 \
     && chmod +x /usr/local/bin/n98-magerun2
 
-COPY common/template/ $TEMPLATE_DIR/
+COPY common/template/custom.ini common/template/xdebug.ini /usr/local/etc/php/conf.d/
+COPY common/template/msmtprc $TEMPLATE_DIR/
 
 COPY common/bin/docker-configure \
      7.x/bin/magento-install \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -45,6 +45,8 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini;
 
+RUN usermod -s $(which bash) www-data
+
 ENV COMPOSER_CACHE_DIR /home/www-data/.composer
 ENV MAIL_HOST mail
 ENV MAIL_PORT 1025
@@ -69,7 +71,8 @@ RUN curl -O https://files.magerun.net/n98-magerun2.phar \
     && mv n98-magerun2.phar /usr/local/bin/n98-magerun2 \
     && chmod +x /usr/local/bin/n98-magerun2
 
-COPY common/template/ $TEMPLATE_DIR/
+COPY common/template/custom.ini common/template/xdebug.ini /usr/local/etc/php/conf.d/
+COPY common/template/msmtprc $TEMPLATE_DIR/
 
 COPY common/bin/docker-configure \
      7.x/bin/magento-install \

--- a/build.sh
+++ b/build.sh
@@ -16,4 +16,4 @@ fi
 docker pull ${REPO}:${PHPVER}
 docker tag ${REPO}:${PHPVER} ${REPO}:${PHPVER}-current
 
-docker build --no-cache -f ${PHPVER}/Dockerfile -t ${REPO}:${PHPVER} ${HERE}
+docker build ${2} -f ${PHPVER}/Dockerfile -t ${REPO}:${PHPVER} ${HERE}

--- a/common/bin/docker-configure
+++ b/common/bin/docker-configure
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-envsubst < $TEMPLATE_DIR/xdebug.ini > /usr/local/etc/php/conf.d/xdebug.ini
-envsubst < $TEMPLATE_DIR/custom.ini > /usr/local/etc/php/conf.d/custom.ini
 envsubst < $TEMPLATE_DIR/msmtprc > /etc/msmtprc
 
 [ "$XDEBUG_ENABLE" = "true" ] && docker-php-ext-enable xdebug
 
-exec "$@"
+case $@ in
+    php-fpm*)
+        exec "$@" ;;
+    bash*)
+        exec "$@" ;;
+    *)
+        su www-data -c "$@" ;;
+esac


### PR DESCRIPTION
1) to try to improve file permissions management, we can run the container as root if starting php-fpm or bash, but otherwise sequester to www-data e.g. composer, yarn?

2) no benefit to locally building without cache, replace in build script with arg2. can pass --no-cache directly to the call, as done in circleci config

n.b. I also changed the php ini implementation as PHP will automatically read environment vars where defined, so we just copy them during build now, instead of using `envsubst` unnecessarily.