### PR TITLE
Install latest stable Redis and Xdebug extensions

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -36,7 +36,8 @@ RUN docker-php-ext-install \
     xsl \
     zip
 
-RUN pecl install -o -f xdebug-2.5.0
+RUN pecl install -o -f xdebug redis \
+    && docker-php-ext-enable redis
 
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -37,7 +37,8 @@ RUN docker-php-ext-install \
     xsl \
     zip
 
-RUN pecl install -o -f xdebug-2.5.0
+RUN pecl install -o -f xdebug redis \
+    && docker-php-ext-enable redis
 
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -37,7 +37,8 @@ RUN docker-php-ext-install \
     xsl \
     zip
 
-RUN pecl install -o -f xdebug-2.5.0
+RUN pecl install -o -f xdebug redis \
+    && docker-php-ext-enable redis
 
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \


### PR DESCRIPTION
Install latest stable `redis` extension via `pecl`
Switch up so image builds latest stable release of `xdebug` too. 

I'm not really sure how much of an improvement this makes, however seems to be working fine so worth having anyway. 

