### PR TITLE
Adding Sockets PHP extension

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -35,7 +35,8 @@ RUN docker-php-ext-install \
     soap \
     xsl \
     zip \
-    sodium
+    sodium \
+    sockets
 
 RUN pecl install -o -f xdebug
 


### PR DESCRIPTION
This PHP extension is required by the latest ECE-Tools for Cloud projects